### PR TITLE
Fix Windows Date Parse Bug

### DIFF
--- a/knackpy/__init__.py
+++ b/knackpy/__init__.py
@@ -5,6 +5,7 @@
 import csv
 import json
 import logging
+import pdb
 
 import arrow
 import requests
@@ -388,10 +389,11 @@ class Knack(object):
                             d = int( record[field]['unix_timestamp'] )
 
                             if self.tzinfo:
-                                #  convert from mills and replace timezone
-                                d = arrow.get(d / 1000).replace(tzinfo=self.tzinfo)
+                                d = arrow.get(0).shift(seconds=d/1000).replace(tzinfo=self.tzinfo)
+
                                 #  convert back to mills
                                 d = d.timestamp * 1000
+                                
                         else:
                             d = ''
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='knackpy',
-    version='0.0.1',
+    version='0.0.2',
     description='Python API wrapper for interacting with Knack applications.',
     url='http://github.com/cityofaustin/knack-py',
     author='John Clary',


### PR DESCRIPTION
This fixes an error that crops up in windows when arrow tries to "get" negative timestamps. I.e., it fails. The work around is to "get" a timestamp at 0 seconds, then pass the negative timestamp to the shift method.