### PR TITLE
Parse Empty Multi-Choice Arrays to Empty Strings

### DIFF
--- a/knackpy/__init__.py
+++ b/knackpy/__init__.py
@@ -1,11 +1,10 @@
 #  todo:
-#  tests
 #  no support for time, date ranges, timer, image, or files
 
 import csv
 import json
 import logging
-
+import pdb
 import arrow
 import requests
 
@@ -360,6 +359,7 @@ class Knack(object):
                                 fieldnames.append(subfield_label)
 
                     elif field_type =='multiple_choice':
+                            
                         fieldnames.append(field_label)
 
                         field_val = stringify_ambiguous_field(record[field])
@@ -380,6 +380,7 @@ class Knack(object):
                                 fieldnames.append(subfield_label)
 
                     elif field_type in ['date', 'date_time']:
+                        
                         fieldnames.append(field_label)
                         #  get unix timestamps from datetime fields
                         #  ignore other subfields
@@ -481,7 +482,6 @@ class Knack(object):
 
         return None
 
-
 #  helper functions
 def stringify_ambiguous_field( *field_values ):
         #  return a comma-separated string of field values
@@ -491,8 +491,10 @@ def stringify_ambiguous_field( *field_values ):
         #  https://stackoverflow.com/questions/836387/how-can-i-tell-if-a-python-variable-is-a-string-or-a-list
         if len(field_values) > 1:
             return ','.join(str(f) for f in field_values)
-        else:
+        elif len(field_values) == 1 and field_values[0]:
             return field_values[0]
+        else:
+            return ''
 
 def update_record(record_dict, knack_object, id_key, app_id, api_key, timeout=10):
     print('update knack record')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='knackpy',
-    version='0.0.1',
+    version='0.0.3',
     description='Python API wrapper for interacting with Knack applications.',
     url='http://github.com/cityofaustin/knack-py',
     author='John Clary',


### PR DESCRIPTION
When a multi-choice knack field is empty, it results in the field value stored as an empty array. The empty arrays were causing problems for some of my downstream processes, and I don't see a reason to keep them, so the parse_data method now converts those empty arrays to empty strings.