### PR TITLE
v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Knackpy requires Python v3.6+.
 pip install knackpy
 ```
 ## Features
+
 - [Object](#object-based-requests) and [view-based](#view-based-requests) requests
 - [Filters](#filters)
 - [Parsing of fieldnames and field labels](#field-data)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ pip install knackpy
 >>> kn = Knack(
       obj='object_1',
       app_id='abc123',
-      api_key='topsecretapikey'
+      api_key='topsecretapikey',
+      tzinfo="US/Central" # Be careful, this is the default value!
     )
    
 >>> kn.data
@@ -146,11 +147,13 @@ You can download files for the records you retrieve from a view. Files are overw
 
 ### CSV Output
 
+You can write Knack data to a `CSV` file. Note that timestamps are converted to ISO 8601 format when written to CSV.
+
 ```python
 >>> kn.to_csv('data.csv')
 "store_id","inspection_date","store_status"
-"30424","11-18-2016","OPEN"
-"30200","10-01-2013","CLOSED"
+"30424","2020-01-05T15:05:00-05:00","OPEN"
+"30200","2020-01-05T15:05:00-05:00","CLOSED"
 ...
 ```
 
@@ -226,7 +229,7 @@ Get an app's configuration data (objects, scenes, etc.)
 
 Use `rows_per_page` (default=`1000`) and/or `page_limit` (default=`1000`) to limit results. 
 
-Note that maximum rows-per-page allowed by the Knack api is 1000.
+Note that maximum rows-per-page allowed by the Knack API is 1000.
 
 ```python
 >>> kn = Knack(
@@ -237,6 +240,31 @@ Note that maximum rows-per-page allowed by the Knack api is 1000.
       page_limit=1
     )
 
+```
+
+### Localization and Timezone Settings
+
+*Note that knackpy's default timezone value is `US/Central`.*
+
+#### A Note about Knack Timestamps
+
+You may be wondering why timezone settings are concern, given that Knackpy, like the Knack API, returns timestamp values as Unix timestamps in millesconds (thus, there is no timezone encoding at all). However, the Knack API confusingly returns *millisecond timestamps in your localized  timezone*!
+
+For example, if you inspect a timezone value in Knack, e.g., `1578254700000`, this value represents  Sunday, January 5, 2020 8:05:00 PM *local time*.
+
+To address this, knackpy handles the conversion of Knack timestamps into *real* unix timestamps which are time-zone naive. However, the original "local timestamps" are preserved in the `Knack.data_raw` object. If you're working with that data, you'll need to convert the tiemstamps yourself. See the `Knack._convert_timestamps` method in the source code for help.
+
+#### Setting your timezone
+
+Use the `tzinfo` parameter to specify your applications timezone setting. This value should be formatted as a timezone string compliant to the [tz database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+ 
+```python
+>>> kn = Knack(
+      obj='object_1',
+      app_id='abc123',
+      api_key='topsecretapikey',
+      tzinfo="US/Central" # Be careful, this is the default value!
+    )
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ pip install knackpy
 - [File downloads](#file-downloads)
 - [Page and Row Limitng](#page-and-row-limiting)
 - [Localization and Timezone Settings](#localization-and-timezone-settings)
-- [Retry]
-- [Raw Connections]
+- [Connection Fields](#connection-fields)
+- [Timeouts and Retrying](#timeouts-and-retrying)
 - [Include Ids, ID Key]
 
 
@@ -263,6 +263,21 @@ Use the `tzinfo` parameter to specify your applications timezone setting. This v
       obj='object_1',
       app_id='abc123',
       api_key='topsecretapikey',
+      tzinfo="US/Central" # Be careful, this is the default value!
+    )
+```
+
+### Timeouts and Retrying
+
+By default, knackpy will attempt to send an HTTP request to the Knack API 5 times until a status code of `200` is returned. You can adjust the number of request attempts (`max_attempts`, default=`5`) and the timeout (`timeout`, default=`10`):
+
+```python
+>>> kn = Knack(
+      obj='object_1',
+      app_id='abc123',
+      api_key='topsecretapikey',
+      max_attempts=4,
+      timeout=20,
       tzinfo="US/Central" # Be careful, this is the default value!
     )
 ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can download files for the records you retrieve from a view. Files are overw
  >>> kn.download(overwrite=False) # Writes all new files to `_downloads` directory
 
 >>> kn.download(
-  destination="my_downloads",
+  destination="my_downloads", # Writes to `my_downloads` directory
   label_fields=["Attachment ID", "Date"], # Prepends the "Attachment ID" and "Date" values to the filename
   download_fields=["Photo", "Document"] # Downloads files from these specific fields only
 )

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ You may be wondering why timezone settings are concern, given that Knackpy, like
 
 For example, if you inspect a timezone value in Knack, e.g., `1578254700000`, this value represents  Sunday, January 5, 2020 8:05:00 PM *local time*.
 
-To address this, knackpy handles the conversion of Knack timestamps into *real* unix timestamps which are time-zone naive. However, the original "local timestamps" are preserved in the `Knack.data_raw` object. If you're working with that data, you'll need to convert the tiemstamps yourself. See the `Knack._convert_timestamps` method in the source code for help.
+To address this, knackpy handles the conversion of Knack timestamps into *real* millisecond unix timestamps which are timezone naive. However, the original "local timestamps" are preserved in the `Knack.data_raw` object. If you're working with that data, you'll need to convert the tiemstamps yourself. See the `Knack._convert_timestamps` method in the source code for help.
 
 #### Setting your timezone
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,21 @@ By default, knackpy will attempt to send an HTTP request to the Knack API 5 time
     )
 ```
 
+### Connection Fields
+
+By default connection fields are (if one connection) returned as the field's display name, or (if many connetions) an array of the connection fields' display names.
+
+Use `raw_connections=True` to retain the entire connection array from Knack:
+
+```python
+[
+  {
+    "id": "5a7a027b82fecf67ab01f263", # Record ID of connected record
+    "identifier": "Pizza Hut" # This the value of the connection's display name field
+  }
+],
+```
+
 ## License
 
 As a work of the City of Austin, this project is in the public domain within the United States.

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ By default, knackpy will attempt to send an HTTP request to the Knack API 5 time
 
 ### Connection Fields
 
-By default connection fields are (if one connection) returned as the field's display name, or (if many connetions) an array of the connection fields' display names.
+By default, connection fields are (if one connection) returned as the field's display name, or (if many connetions) an array of the connection fields' display names.
 
 Use `raw_connections=True` to retain the entire connection array from Knack:
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,21 @@ Knackpy requires Python v3.6+.
 ```
 pip install knackpy
 ```
-## Features
+
+## Quick Start
+
+```python
+>>> kn = Knack(
+      obj='object_1',
+      app_id='abc123',
+      api_key='topsecretapikey'
+    )
+   
+>>> kn.data
+[{'store_id': 30424, 'inspection_date': 1479448800000, 'id': '58598262bcb3437b51194040'},...]
+```
+
+## Documentation
 
 - [Object](#object-based-requests) and [view-based](#view-based-requests) requests
 - [Filters](#filters)
@@ -17,8 +31,12 @@ pip install knackpy
 - [Create, update, and delete records](#create-update-or-delete-records)
 - [CSV output](#csv-output)
 - [File downloads](#file-downloads)
+- [Page and Row Limitng](#page-and-row-limiting)
+- [Localization and Timezone Settings](#localization-and-timezone-settings)
+- [Retry]
+- [Raw Connections]
+- [Include Ids, ID Key]
 
-## Quick Start
 
 ### View-Based Requests
 
@@ -202,6 +220,23 @@ Get an app's configuration data (objects, scenes, etc.)
 >>> my_app['name']
 
 "John's Amazing App"
+```
+
+### Page and Row Limiting
+
+Use `rows_per_page` (default=`1000`) and/or `page_limit` (default=`1000`) to limit results. 
+
+Note that maximum rows-per-page allowed by the Knack api is 1000.
+
+```python
+>>> kn = Knack(
+      obj='object_1',
+      app_id='abc123',
+      api_key='topsecretapikey',
+      rows_per_page=1, # 
+      page_limit=1
+    )
+
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -10,14 +10,16 @@ Knackpy requires Python v3.6+.
 pip install knackpy
 ```
 ## Features
-- Object and view-based requests
-- Filters
-- Parsing of fieldnames and field labels
-- Create and update records
-- CSV output
-- File downloads
+- [Object](#object-based-requests) and [view-based](#view-based-requests) requests
+- [Filters](#filters)
+- [Parsing of fieldnames and field labels](#field-data)
+- [Create, update, and delete records](#create-update-or-delete-records)
+- [CSV output](#csv-output)
+- [File downloads](#file-downloads)
 
 ## Quick Start
+
+### View-Based Requests
 
 Get data from a Knack view.
 
@@ -49,7 +51,9 @@ Provide a list of the view's reference objects to return humanized field names.
 [{'store_id': 30424, 'inspection_date': 1479448800000, 'id': '58598262bcb3437b51194040'},...]
 ```
 
-Or retrieve data directly from an object.
+### Object-Based Requests
+
+Retrieve data directly from an object.
 
 ```python
 >>> kn = Knack(
@@ -62,7 +66,9 @@ Or retrieve data directly from an object.
 [{'store_id': 30424, 'inspection_date': 1479448800000, 'id': '58598262bcb3437b51194040'},...]
 ```
 
-You can also pass a [filter](https://www.knack.com/developer-documentation/#filters) to your object-based requests. 
+### Filters
+
+You can pass a [filter](https://www.knack.com/developer-documentation/#filters) to object-based requests. 
 
 ```python
 
@@ -90,7 +96,9 @@ You can also pass a [filter](https://www.knack.com/developer-documentation/#filt
     )
 ```
 
-Field metadata is available when working with objects or when reference objects have been specified.
+### Field Data
+
+Field metadata is available in object-based requests or in view-based requests when reference objects have been specified.
 
 ```python
 >>> kn.fields
@@ -103,19 +111,21 @@ Field metadata is available when working with objects or when reference objects 
 {'store_id' : 'field_1', 'store_status' : 'field_2',...}
 ```
 
+### File Downloads
+
 You can download files for the records you retrieve from a view. Files are overwritten by default:
 
 ```python
  >>> kn.download(overwrite=False) # Writes all new files to `_downloads` directory
 
 >>> kn.download(
-  destination="my_downloads", # Overwrites existing files in `my_downloads` directory
-  label_fields=["Attachment ID"], # Prepends the "Attachment ID" value to the filename
-  download_fields=["Photo", "Document"] # downloads files from these specific fields only
+  destination="my_downloads",
+  label_fields=["Attachment ID", "Date"], # Prepends the "Attachment ID" and "Date" values to the filename
+  download_fields=["Photo", "Document"] # Downloads files from these specific fields only
 )
 ```
 
-Write an instance to csv.
+### CSV Output
 
 ```python
 >>> kn.to_csv('data.csv')
@@ -124,6 +134,8 @@ Write an instance to csv.
 "30200","10-01-2013","CLOSED"
 ...
 ```
+
+### Create, Update, or Delete Records
 
 Create a new record.
 
@@ -140,7 +152,7 @@ Create a new record.
       method='create'
     )
 
-{ 'id':'6a204bd89f3c8348afd5c77c717a097a', field_1': 30424, ...}
+{ 'id':'6a204bd89f3c8348afd5c77c717a097a', 'field_1': 30424, ...}
 ```
 
 Update a record.
@@ -158,8 +170,27 @@ Update a record.
       method='update'
     )
     
-{ 'id':'6a204bd89f3c8348afd5c77c717a097a', field_1': 2049, ...}
+{ 'id':'6a204bd89f3c8348afd5c77c717a097a', 'field_1': 2049, ...}
 ```
+
+Delete a record
+
+```python
+>>> record = {'id':'6a204bd89f3c8348afd5c77c717a097a'}
+
+>>> response = knackpy.record(
+      record,
+      obj_key='object_12',
+      app_id='myappid',
+      api_key='topsecretapikey',
+      method='delete'
+    )
+
+# API returns `{'delete': True}`
+```    
+
+### App Data
+
 Get an app's configuration data (objects, scenes, etc.)
 
 ```python
@@ -169,7 +200,7 @@ Get an app's configuration data (objects, scenes, etc.)
 
 >>> my_app['name']
 
-'John's Amazing App'
+"John's Amazing App"
 ```
 
 ## License
@@ -177,4 +208,3 @@ Get an app's configuration data (objects, scenes, etc.)
 As a work of the City of Austin, this project is in the public domain within the United States.
 
 Additionally, we waive copyright and related rights of the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
-

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ pip install knackpy
 - [Localization and Timezone Settings](#localization-and-timezone-settings)
 - [Connection Fields](#connection-fields)
 - [Timeouts and Retrying](#timeouts-and-retrying)
-- [Include Ids, ID Key]
-
+- [Knack Record ID's](#knack-record-ids)
 
 ### View-Based Requests
 
@@ -296,6 +295,10 @@ Use `raw_connections=True` to retain the entire connection array from Knack:
   }
 ],
 ```
+
+### Knack Record ID's
+
+By default, the Knack record ID is included within each record under the `id` key. This can create problems if you have a field named `id` in our object. You can exclude the record IDs entirely with `include_ids=False` or set your own ID key with `id_key="your_field_id"`. 
 
 ## License
 

--- a/knackpy/knackpy.py
+++ b/knackpy/knackpy.py
@@ -22,7 +22,7 @@ class Knack(object):
         localize=True,
         max_attempts=5,
         obj=None,
-        page_limit=10,
+        page_limit=1000,
         raw_connections=False,
         rows_per_page=1000,
         ref_obj=None,

--- a/knackpy/knackpy.py
+++ b/knackpy/knackpy.py
@@ -19,7 +19,6 @@ class Knack(object):
         filters=None,
         include_ids=True,
         id_key="id",
-        localize=True,
         max_attempts=5,
         obj=None,
         page_limit=1000,
@@ -128,6 +127,9 @@ class Knack(object):
                 but not both.
                 """
             )
+
+        if self.rows_per_page > 1000:
+            print("Warning: maximum rows per page is 1000. Only 1000 rows per page will be returned.")
 
         self.endpoint = self._get_endpoint()
         self.data_raw = self._get_data(self.endpoint, "records", self.filters)
@@ -433,7 +435,11 @@ class Knack(object):
 
                     elif field_type == "file" or field_type == "image":
                         fieldnames.append(field_label)
-                        new_record[field_label] = record[field].get("url")
+                        
+                        if record[field]:
+                            new_record[field_label] = record[field].get("url")
+                        else:
+                            new_record[field_label] =  ""
 
                     else:
                         fieldnames.append(field_label)

--- a/knackpy/knackpy.py
+++ b/knackpy/knackpy.py
@@ -336,6 +336,7 @@ class Knack(object):
                             "longitude",
                             "formatted_value",
                             "street",
+                            "street2",
                             "city",
                             "state",
                             "country",

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     url='http://github.com/cityofaustin/knackpy',
-    version='0.0.14',
+    version='0.1.0',
 )

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     url='http://github.com/cityofaustin/knackpy',
-    version='0.0.13',
+    version='0.0.14',
 )


### PR DESCRIPTION
- Much better docs
- Fixed support for image file downloads
- Support for `street2` address subfield [#28]
- Increase default page limit from `10` to `1000`
- Bumping to v0.1.0 for those using the default page limit of `10`
