### PR TITLE
V1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,25 @@ $ pip install knackpy-dev
 >>> records_formatted = [record.format() for record in records]
 ```
 
-## The `App` Class
+## The `App` Class (`knackpy.App()`)
 
 The Knackpy API is designed around the `App()` class, which provides helpers for query and manipulating data from a Knack application.
+
+### Args:
+
+- `app_id` (`str`): Knack [application ID](https://www.knack.com/developer-documentation/#find-your-api-key-amp-application-id) string.
+
+- `api_key` (`str`, optional, default=`None`): Knack [API key](https://www.knack.com/developer-documentation/#find-your-api-key-amp-application-id).
+
+- `metadata` (`dict`, optional, default=`None`): The Knack app's metadata as a `dict`. If `None` it will be fetched on init. You can find your apps metadata at [here](https://loader.knack.com/v1/applications/5d79512148c4af00106d1507).
+
+- `tzinfo` (`pytz.Timezone`, optional): A [pytz.Timezone](https://pythonhosted.org/pytz/) object. Defaults to None. When None, is set automatically based on the app's `metadadata`.
+
+- `max_attempts` (`int`): The maximum number of attempts to make if a request times out. Default values that are set in `knackpy.api.request`.
+
+- `timeout` (`int`, optional, default=`30`): Number of seconds to wait before a Knack API request times out.
+
+### Usage
 
 To create an `App` instance, the bare minimum you need to provide is your [application ID](https://www.knack.com/developer-documentation/#find-your-api-key-amp-application-id).
 
@@ -134,8 +150,8 @@ Write formatted Knack records to CSV. Be aware that destination will be overwrit
 Args:
 
 - `name_or_key` (`str`): an object or view key or name string that exists in the app.
-- `out_dir` (`str`, *optional*): Relative path to the directory to which files will be written. Defaults to "\_csv"
-- `delimiter` (`str`, *optional*): The delimiter characte(s). Defaults to comma (`,`).
+- `out_dir` (`str`, optional): Relative path to the directory to which files will be written. Defaults to "\_csv"
+- `delimiter` (`str`, optional): The delimiter characte(s). Defaults to comma (`,`).
 
 -
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,20 @@ _Knackpy v1.0 is under development. Documented methods should work, but check th
 
 ## Table of Contents
 
-- Installation
-- Quick Start
-- The `App` Class
-- Working with Records and Fields
-- CRUD Operations
-- File Uploads and Downloads
-- Advanced Methods
-- Timestamps and Localization
-- Logging and Exceptions
-- Migrating from Knackpy `v0.1`
-- Contributing
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Modules](#modules)
+  - [App](#app)
+  - [Records](#records)
+  - [Fields](#fields)
+  - [Api](#api)
+  - [CRUD Operations](#crud-operations)
+- [File Uploads and Downloads](#file-uploads-and-downloads)
+- [Advanced Usage](#advanced-usage)
+- [Timestamps and Localization](#timestamps-and-localization)
+- [Exceptions](#exceptions)
+- [Migrating from `v0.1`](#migrating-from-v0.1)
+- [Contributing](#contributing)
 
 ## Installation
 
@@ -37,11 +40,13 @@ $ pip install knackpy-dev
 >>> records_formatted = [record.format() for record in records]
 ```
 
-## The `App` Class (`knackpy.App()`)
+## Modules
 
-The Knackpy API is designed around the `App()` class, which provides helpers for query and manipulating data from a Knack application.
+### `App`
 
-### Args:
+Knackpy is designed around the `App` class, which provides helpers for querying and manipulating Knack application data. `App` also takes care of [localization issues](#timestamps-and-localization), so you don't have to worry about them.
+
+##### Args
 
 - `app_id` (`str`): Knack [application ID](https://www.knack.com/developer-documentation/#find-your-api-key-amp-application-id) string.
 
@@ -53,13 +58,13 @@ The Knackpy API is designed around the `App()` class, which provides helpers for
 
 - `max_attempts` (`int`): The maximum number of attempts to make if a request times out. Default values that are set in `knackpy.api.request`.
 
-- `timeout` (`int`, optional, default=`30`): Number of seconds to wait before a Knack API request times out.
+- `timeout` (`int`, optional, default=`30`): Number of seconds to wait before a Knack API request times out. Further reading: [Requests docs](https://requests.readthedocs.io/en/master/user/quickstart/#timeouts).
 
-### Usage
+##### Usage
 
 To create an `App` instance, the bare minimum you need to provide is your [application ID](https://www.knack.com/developer-documentation/#find-your-api-key-amp-application-id).
 
-If you construct an `App` instance without also providing an API key, you will only be able to fetch records from publicly-availble views.
+If you construct an `App` instance without providing an API key, you will only be able to fetch records from publicly-availble views.
 
 Note that fetching data from public views is a smart way to avoid hitting your [API limit](https://www.knack.com/developer-documentation/#api-limits).
 
@@ -69,32 +74,54 @@ Note that fetching data from public views is a smart way to avoid hitting your [
 >>> my_app = knackpy.App(app_id="myappid", api_key="myverysecretapikey")
 ```
 
-### Accessing Records
+#### `App.records()`
 
-To fetch records, use `App.records(<container_name:str>)`.
+Fetch records from a Knack application.
+
+##### Args
+
+- `name_or_key` (`str`): An object or view key or name string that exists in the app.
+- `refresh` (`bool`, optional, default=`None`): If true, will re-fetch the records from the Knack API, regardless of if they have already been downloaded.
+- `record_limit` (`int`, optional, default=`None`): The maximum number of records to retrieve. If `None`, all records will be downloaded.
+- `filters` (`dict` or `list`, optional): A `dict` or `list` of query filters to be applied, per [Knack's specification](https://www.knack.com/developer-documentation/#filters).
+
+##### Returns
+
+A generator function which yields `knackpy.Record` objects.
+
+##### Usage
 
 ```python
 # fetch all records from object_1
 >>> records = my_app.records("object_1")
 ```
 
-Container identifiers can be supplied as an object or view key (`object_1`, `view_1`) or name (`my_exciting_object`, `My Exciting View`).
-
-Note that namespace conflicts are highly likely when fetching by name, because Knack uses object names as the default name for views. If you attempt to query your application by a name that exists as both an object and a view, Knackpy will raise a `ValueError`.
-
 ```python
 # fetch all records from view named "My Exciting View"
 >>> records = my_app.records("My Exciting View")
 ```
 
+Container identifiers can be supplied as an object or view key (`object_1`, `view_1`) or name (`my_exciting_object`, `My Exciting View`).
+
+Note that namespace conflicts are highly likely when fetching by name, because Knack uses object names as the default name for views. If you attempt to query your application by a name that exists as both an object and a view, Knackpy will raise a `ValueError`.
+
 `App.records()` returns a generator. You'll need to re-intialize it with `App.records(<container:str>)` each time you iterate on your records.
 
 ```python
 >>> records_formatted = [
-...    record.format() for record in my_app.record("my_exciting_object")
+...    record.format() for record in my_app.records("my_exciting_object")
 ... ]
 # re-intialize the records generator
->>> records_raw = [record.raw for record in my_app.records("my_exciting_object")]
+>>> records_raw = [record.raw for record in my_app.recordss("my_exciting_object")]
+```
+
+If you've only fetched one container, you can omit the container name when accessing your records. This is helpful during development, but for readability we suggest you avoid this practice in production code.
+
+```python
+>>> my_app = knackpy.App(app_id="myappid")
+>>> records = [record for record in my_app.records("My Exciting View")]
+# you can omit the container name if you want to access your records again
+>>> same_records_without_accessor = [record for record in my_app.records()]
 ```
 
 Once you've constructed an `App` instance, you can resuse it to fetch records from other objects and views. This cuts down on calls to Knack's metadata API.
@@ -130,45 +157,6 @@ References to all available endpoints are stored at `App.containers`. This is ha
 ]
 ```
 
-You can use `knackpy.records()` to fetch "raw" data from your Knack app. Be aware that raw Knack timestamps [are problematic](#timestamps-and-localization).
-
-### Other `App` Methods
-
-#### `App.info()`
-
-Display summary metrics about the app.
-
-```python
->>> app.info()
-{'objects': 10, 'scenes': 4, 'records': 6786, 'size': '25.47mb'}
-```
-
-#### `App.to_csv()`
-
-Write formatted Knack records to CSV. Be aware that destination will be overwritten, if they exist.
-
-Args:
-
-- `name_or_key` (`str`): an object or view key or name string that exists in the app.
-- `out_dir` (`str`, optional): Relative path to the directory to which files will be written. Defaults to "\_csv"
-- `delimiter` (`str`, optional): The delimiter characte(s). Defaults to comma (`,`).
-
--
-
-## Advanced Methods
-
-```python
-# This is equivalent to exporting records in JSON format from the Knack Builder
->>> import knackpy
->>> data = knackpy.get(
-...     app_id="myappid",
-...     api_key="myverysecretapikey",
-...     obj="object_1",
-...     record_limit=None,
-...     timeout=30
-... )
-```
-
 You can cut down on API calls by providing your own Knack metadata when creating an `App` instance:
 
 ```python
@@ -187,6 +175,47 @@ You can side-load record data into your your app as well. Note that you must ass
 >> app.data = data
 >> records = [record.format() for record in app.records("object_3")]
 ```
+
+You can use `knackpy.records()` to fetch "raw" data from your Knack app. Be aware that raw Knack timestamps [are problematic](#timestamps-and-localization). See the [Records](#records) documentation.
+
+
+### Other `App` Methods
+
+#### `App.info()`
+
+Display summary metrics about the app.
+
+```python
+>>> app.info()
+{'objects': 10, 'scenes': 4, 'records': 6786, 'size': '25.47mb'}
+```
+
+#### `App.to_csv()`
+
+Write formatted Knack records to CSV. Be aware that destination will be overwritten, if they exist.
+
+##### Args
+
+- `name_or_key` (`str`): an object or view key or name string that exists in the app.
+- `out_dir` (`str`, optional): Relative path to the directory to which files will be written. Defaults to "\_csv"
+- `delimiter` (`str`, optional): The delimiter characte(s). Defaults to comma (`,`).
+
+-
+
+### Api
+
+```python
+# This is equivalent to exporting records in JSON format from the Knack Builder
+>>> import knackpy
+>>> data = knackpy.get(
+...     app_id="myappid",
+...     api_key="myverysecretapikey",
+...     obj="object_1",
+...     record_limit=None,
+...     timeout=30
+... )
+```
+
 
 ## What's New in v1.0
 
@@ -212,22 +241,39 @@ Issues and pull requests are welcome. Know that your contributions are donated t
 
 ## Timestamps and Localization
 
-Although the Knack API returns timestamp values as Unix timestamps in millesconds these raw values represent millisecond timestamps _in your localized timezone_. For example a Knack timestamp value of `1578254700000` represents Sunday, January 5, 2020 8:05:00 PM _local time_.
+Although the Knack API returns timestamp values as Unix timestamps in millesconds, these raw values represent millisecond timestamps _in your localized timezone_. For example a Knack timestamp value of `1578254700000` represents Sunday, January 5, 2020 8:05:00 PM _local time_.
 
-To address this, the `App` class handles the conversion of Knack timestamps into _real_ millisecond unix timestamps which are timezone naive. Timestamps are corrected by referencing the timezone info in your apps metadata. You can manually override your app's timezone information by passing an [IANA-compliant](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) timezone string to your `App` instance, like so:
+To address this, the `App` class converts Knack timestamps into _real_ (UTC-based) unix timestamps. Timestamps are corrected by referencing the timezone info in your apps metadata. You can manually override your app's timezone information by passing an [IANA-compliant](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) timezone string to your `App` instance, like so:
 
 ```python
 >>> app = knackpy.App(app_id="myappid",  api_key="myverysecretapikey", tzinfo="US/Eastern")
 ```
 
-If you'd like to access your raw, uncorrected records, they can be found at `app.data[<container_name:str>]`.
+If you'd like to access your raw, uncorrected records, they can be found at `App.data[<container_name:str>]`.
 
 Note also that `Record` objects return corrected timestamps via `Record.raw` and `Record.format()`. So,
 
 ```python
->>> app = knackpy.App(app_id="myappid",  api_key="myverysecretapikey", tzinfo="US/Eastern")
+>>> my_app = knackpy.App(app_id="myappid",  api_key="myverysecretapikey", tzinfo="US/Eastern")
 # yields raw records with corrected millisecond timestamps
 >>> records_raw = [record.raw for record in app.records("object_3")]
 # yields corrected timestamps as ISO-8601 strings
 >>> records_formatted = [record.format() for record in app.records("object_3")]
+```
+
+## Exceptions
+
+Knackpy uses Python's built-in exceptions, as well as Requests's [exceptions](https://requests.readthedocs.io/en/master/user/quickstart/#errors-and-exceptions) when interacting with the Knack API.
+
+If you need to inspect an API exception (for example to see the text content of the response), you can access the `Response` object by handling the exception like so:
+
+```python
+>>> my_app = knackpy.App(api_key="myappid")
+# raises HTTPError. You cannot request object records without supplying an API key
+>>> try:
+...       records = my_app.records("object_1")
+... except HTTPError as e:
+...     print(e.response.text)
+...     raise e
+# 'Unauthorized Object Access'
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ pip install knackpy-dev
 
 The Knackpy API is designed around the `App()` class, which provides helpers for query and manipulating data from a Knack application.
 
-To create an `App` instance, the bare minimum you need to provide is your [application ID](https://www.knack.com/developer-documentation/#find-your-api-key-amp-application-id). 
+To create an `App` instance, the bare minimum you need to provide is your [application ID](https://www.knack.com/developer-documentation/#find-your-api-key-amp-application-id).
 
 If you construct an `App` instance without also providing an API key, you will only be able to fetch records from publicly-availble views.
 
@@ -114,9 +114,30 @@ References to all available endpoints are stored at `App.containers`. This is ha
 ]
 ```
 
-
 You can use `knackpy.records()` to fetch "raw" data from your Knack app. Be aware that raw Knack timestamps [are problematic](#timestamps-and-localization).
 
+### Other `App` Methods
+
+#### `App.info()`
+
+Display summary metrics about the app.
+
+```python
+>>> app.info()
+{'objects': 10, 'scenes': 4, 'records': 6786, 'size': '25.47mb'}
+```
+
+#### `App.to_csv()`
+
+Write formatted Knack records to CSV. Be aware that destination will be overwritten, if they exist.
+
+Args:
+
+- `name_or_key` (`str`): an object or view key or name string that exists in the app.
+- `out_dir` (`str`, *optional*): Relative path to the directory to which files will be written. Defaults to "\_csv"
+- `delimiter` (`str`, *optional*): The delimiter characte(s). Defaults to comma (`,`).
+
+-
 
 ## Advanced Methods
 
@@ -131,8 +152,6 @@ You can use `knackpy.records()` to fetch "raw" data from your Knack app. Be awar
 ...     timeout=30
 ... )
 ```
-
-
 
 You can cut down on API calls by providing your own Knack metadata when creating an `App` instance:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@
 
 _Knackpy v1.0 is under development. Documented methods should work, but check the status badge ^^_
 
+## Table of Contents
+
+- Installation
+- Quick Start
+- The `App` Class
+- Working with Records and Fields
+- CRUD Operations
+- File Uploads and Downloads
+- Advanced Methods
+- Timestamps and Localization
+- Logging and Exceptions
+- Migrating from Knackpy `v0.1`
+- Contributing
+
 ## Installation
 
 Knackpy requires Python v3.6+. To use the development version Knackpy v1.0, install with:
@@ -16,31 +30,44 @@ $ pip install knackpy-dev
 
 ## Quick Start
 
-You can use `knackpy.records()` to fetch "raw" data from your Knack app. Be aware that raw Knack timestamps [are problematic](#timestamps-and-localization).
-
 ```python
-# This is equivalent to exporting records in JSON format from the Knack Builder
 >>> import knackpy
->>> data = knackpy.records(
-...     app_id="myappid",
-...     api_key="myverysecretapikey",
-...     obj="object_1",
-...     record_limit=None,
-...     timeout=30
-... )
-```
-
-More likely, you'll want to use the `App` class to correct and format your data.
-
-```python
 >>> app = knackpy.App(app_id="myappid",  api_key="myverysecretapikey")
 >>> records = app.records("object_1")
 >>> records_formatted = [record.format() for record in records]
 ```
 
-Container identifiers can be supplied as Knack keys (`object_1`, `view_1`) or names (`my_exciting_object`, `My Exciting View`)
+## The `App` Class
+
+The Knackpy API is designed around the `App()` class, which provides helpers for query and manipulating data from a Knack application.
+
+To create an `App` instance, the bare minimum you need to provide is your [application ID](https://www.knack.com/developer-documentation/#find-your-api-key-amp-application-id). 
+
+If you construct an `App` instance without also providing an API key, you will only be able to fetch records from publicly-availble views.
+
+Note that fetching data from public views is a smart way to avoid hitting your [API limit](https://www.knack.com/developer-documentation/#api-limits).
 
 ```python
+# Basic app construction with API key
+>>> import knackpy
+>>> app = knackpy.App(app_id="myappid", api_key="myverysecretapikey")
+```
+
+### Accessing Records
+
+To fetch records, use the `.records(<container_name:str>)` method.
+
+```python
+# fetch all records from object_1
+>>> records = app.records("object_1")
+```
+
+Container identifiers can be supplied as an object or view key (`object_1`, `view_1`) or name (`my_exciting_object`, `My Exciting View`).
+
+Note that namespace conflicts are highly likely when fetching by name, because Knack uses object names as the default name for views. If you attempt to query your application by a name that exists as both an object and a view, Knackpy will raise a `ValueError`.
+
+```python
+# fetch all records from object named "my_exciting_object"
 >>> records = app.records("my_exciting_object")
 ```
 
@@ -87,6 +114,26 @@ References to all available endpoints are stored at `App.containers`. This is ha
     Container(obj=None, view='view_1', scene='scene_1', name='My Exciting View'),
 ]
 ```
+
+
+You can use `knackpy.records()` to fetch "raw" data from your Knack app. Be aware that raw Knack timestamps [are problematic](#timestamps-and-localization).
+
+
+## Advanced Methods
+
+```python
+# This is equivalent to exporting records in JSON format from the Knack Builder
+>>> import knackpy
+>>> data = knackpy.get(
+...     app_id="myappid",
+...     api_key="myverysecretapikey",
+...     obj="object_1",
+...     record_limit=None,
+...     timeout=30
+... )
+```
+
+
 
 You can cut down on API calls by providing your own Knack metadata when creating an `App` instance:
 

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ If you construct an `App` instance without also providing an API key, you will o
 Note that fetching data from public views is a smart way to avoid hitting your [API limit](https://www.knack.com/developer-documentation/#api-limits).
 
 ```python
-# Basic app construction with API key
+# basic app construction with api key
 >>> import knackpy
->>> app = knackpy.App(app_id="myappid", api_key="myverysecretapikey")
+>>> my_app = knackpy.App(app_id="myappid", api_key="myverysecretapikey")
 ```
 
 ### Accessing Records
 
-To fetch records, use the `.records(<container_name:str>)` method.
+To fetch records, use `App.records(<container_name:str>)`.
 
 ```python
 # fetch all records from object_1
->>> records = app.records("object_1")
+>>> records = my_app.records("object_1")
 ```
 
 Container identifiers can be supplied as an object or view key (`object_1`, `view_1`) or name (`my_exciting_object`, `My Exciting View`).
@@ -67,27 +67,26 @@ Container identifiers can be supplied as an object or view key (`object_1`, `vie
 Note that namespace conflicts are highly likely when fetching by name, because Knack uses object names as the default name for views. If you attempt to query your application by a name that exists as both an object and a view, Knackpy will raise a `ValueError`.
 
 ```python
-# fetch all records from object named "my_exciting_object"
->>> records = app.records("my_exciting_object")
+# fetch all records from view named "My Exciting View"
+>>> records = my_app.records("My Exciting View")
 ```
 
 `App.records()` returns a generator. You'll need to re-intialize it with `App.records(<container:str>)` each time you iterate on your records.
 
 ```python
->>> records = app.records("my_exciting_object")
->>> records_formatted = [record.format() for record in records]
+>>> records_formatted = [
+...    record.format() for record in my_app.record("my_exciting_object")
+... ]
 # re-intialize the records generator
->>> records = app.records("my_exciting_object")
-# these records are raw, but the timestamps have been corrected
->>> records_raw = [record.raw for record in records]
+>>> records_raw = [record.raw for record in my_app.records("my_exciting_object")]
 ```
 
 Once you've constructed an `App` instance, you can resuse it to fetch records from other objects and views. This cuts down on calls to Knack's metadata API.
 
 ```python
->>> app.records("my_exciting_object")
->>> app.records("my_boring_object")
->>> app.records("view_1")
+>>> my_app.records("my_exciting_object")
+>>> my_app.records("my_boring_object")
+>>> my_app.records("view_1")
 ```
 
 By default, an `App` instance will only fetch records for a container once. Use `refresh=True` to force a new fetch from the Knack API.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ $ pip install knackpy-dev
 
 ### `App`
 
-Knackpy is designed around the `App` class, which provides helpers for querying and manipulating Knack application data. `App` also takes care of [localization issues](#timestamps-and-localization), so you don't have to worry about them.
+Knackpy is designed around the `App` class. It provides helpers for querying and manipulating Knack application data. You should use the `App` class because:
+
+- It allows you to query obejcts and views by key or name
+- It takes care of [localization issues](#timestamps-and-localization)
+- It let's you download and upload files from your app.
+- It does other things, too
 
 ##### Args
 
@@ -132,18 +137,11 @@ Once you've constructed an `App` instance, you can resuse it to fetch records fr
 >>> my_app.records("view_1")
 ```
 
-By default, an `App` instance will only fetch records for a container once. Use `refresh=True` to force a new fetch from the Knack API.
-
-```python
->>> records = app.records("my_exciting_object", refresh=True)
-```
-
-You can check the readily available data in your App instance like so:
+Raw record data is available at `App.data`. You can also use this to cehck the readily available data in your App instance, like so:
 
 ```python
 >>> app.data.keys()
 ["object_1", "object_2", "view_1"]
->>> view_1_records = [record.format() for record in app.records("view_22")]
 ```
 
 References to all available endpoints are stored at `App.containers`. This is handy if you want to check the name of a container, or its key:
@@ -178,9 +176,6 @@ You can side-load record data into your your app as well. Note that you must ass
 
 You can use `knackpy.records()` to fetch "raw" data from your Knack app. Be aware that raw Knack timestamps [are problematic](#timestamps-and-localization). See the [Records](#records) documentation.
 
-
-### Other `App` Methods
-
 #### `App.info()`
 
 Display summary metrics about the app.
@@ -198,7 +193,7 @@ Write formatted Knack records to CSV. Be aware that destination will be overwrit
 
 - `name_or_key` (`str`): an object or view key or name string that exists in the app.
 - `out_dir` (`str`, optional): Relative path to the directory to which files will be written. Defaults to "\_csv"
-- `delimiter` (`str`, optional): The delimiter characte(s). Defaults to comma (`,`).
+- `delimiter` (`str`, optional): The delimiter string. Defaults to comma (`,`).
 
 -
 

--- a/coverage.svg
+++ b/coverage.svg
@@ -9,13 +9,13 @@
     </mask>
     <g mask="url(#a)">
         <path fill="#555" d="M0 0h63v20H0z"/>
-        <path fill="#a4a61d" d="M63 0h36v20H63z"/>
+        <path fill="#97CA00" d="M63 0h36v20H63z"/>
         <path fill="url(#b)" d="M0 0h99v20H0z"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">89%</text>
-        <text x="80" y="14">89%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">92%</text>
+        <text x="80" y="14">92%</text>
     </g>
 </svg>

--- a/coverage.svg
+++ b/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">92%</text>
-        <text x="80" y="14">92%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">90%</text>
+        <text x="80" y="14">90%</text>
     </g>
 </svg>

--- a/knackpy/app.py
+++ b/knackpy/app.py
@@ -22,7 +22,7 @@ class App:
 
         Args:
             app_id (str): Knack application ID string.
-            metadata (str, optional): [description]. Defaults to None.
+            metadata (dict, optional): [description]. Defaults to None.
             api_key (str, optional): [description]. Defaults to None.
             tzinfo (pytz.Timezone, optional): [description]. Defaults to None.
             max_attempts (int): the maximum number of attempts to make if a request

--- a/knackpy/app.py
+++ b/knackpy/app.py
@@ -61,7 +61,7 @@ class App:
             else metadata["application"]
         )
         self.tzinfo = tzinfo if tzinfo else self.metadata["settings"]["timezone"]
-        self.timezone = self.get_timezone(self.tzinfo)
+        self.timezone = self._get_timezone(self.tzinfo)
         self.field_defs = fields.field_defs_from_metadata(self.metadata)
         self.containers = utils.generate_containers(self.metadata)
         self.data = {}
@@ -84,7 +84,7 @@ class App:
         }
 
     @staticmethod
-    def get_timezone(tzinfo):
+    def _get_timezone(tzinfo):
         # TODO: move to utils
         """
         Knack stores timezone information in the app metadata, but it does not

--- a/knackpy/records.py
+++ b/knackpy/records.py
@@ -174,9 +174,12 @@ class Records:
         self.timezone = timezone
         self.field_defs = self._filter_field_defs_by_container_key(field_defs)
         # find the identifier field
-        self.identifier = [
-            field_def.key for field_def in self.field_defs if field_def.identifier
-        ][0]
+        try:
+            self.identifier = [
+                field_def.key for field_def in self.field_defs if field_def.identifier
+            ][0]
+        except IndexError:
+            self.identifier = None
 
         return None
 

--- a/knackpy/records.py
+++ b/knackpy/records.py
@@ -61,14 +61,14 @@ class Record(MutableMapping):
         values to the record without issue, but some operations will fail after
         assignment of a non-Field value. e.g., .format() and dict().
 
-        All that to we set immutable = True after init, and attempts to assign
-        will raise a TypeError.
+        All that to say, we set immutable = True after init, and further attempts to
+        __setitem__ will raise a TypeError.
 
         Raises:
             TypeError: 'Record' object does not support item assignment.
         """
-        # if self.immutable and not force:
-        #     raise TypeError("'Record' object does not support item assignment")
+        if self.immutable:
+            raise TypeError("'Record' object does not support item assignment")
 
         self.fields[key] = value
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -117,6 +117,7 @@ def test_no_key_or_name_param(app_static):
     # object_3.
     assert app_static.records()
 
+
 def test_no_key_or_name_param_fail(app_static):
     # the API allows you to use App.reords() (without any key or view name) if only
     # one container has been retrieved. in this case, we side-load additional data
@@ -126,6 +127,7 @@ def test_no_key_or_name_param_fail(app_static):
     app_static.data["fake_data_holder"] = data
     with pytest.raises(TypeError):
         assert app_static.records()
+
 
 def test_get_by_dupe_name_fail(app_static):
     # the "all_fields_test" container name exists in our app as both an object

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,7 +34,9 @@ def app_data():
 def app_static(app_data):
     # app with side-loaded metadata and records
     knackpy_app = knackpy.app.App(
-        app_id=app_data["metadata"]["application"]["id"], metadata=app_data["metadata"]
+        app_id=app_data["metadata"]["application"]["id"],
+        api_key=API_KEY,
+        metadata=app_data["metadata"],
     )
     knackpy_app.data = {"object_3": app_data["data"]}
     return knackpy_app
@@ -59,12 +61,24 @@ def test_constructor_fail_missing_app_id(app_static):
         knackpy.app.App()
 
 
-def test_get_by_key_static(app_static):
+def test_object_get_by_key_static(app_static):
     assert isinstance(app_static.records("object_3"), types.GeneratorType)
 
 
-def test_get_by_key_live(app_live):
+def test_get_object_by_key_live(app_live):
     assert isinstance(app_live.records("object_3"), types.GeneratorType)
+
+
+def test_view_by_key_static(app_static):
+    assert isinstance(app_static.records("view_11"), types.GeneratorType)
+
+
+def test_get_view_by_key_live(app_live):
+    assert isinstance(app_live.records("view_11"), types.GeneratorType)
+
+
+def test_get_view_by_name(app_live):
+    assert isinstance(app_live.records("view_11"), types.GeneratorType)
 
 
 def test_get_by_key_refresh(app_live):
@@ -74,15 +88,27 @@ def test_get_by_key_refresh(app_live):
 
 
 def test_no_api_key_get(app_static):
-    # our static app has been constructed w/o an API key, so object-based requests
-    # should fail with an HTTPError
     with pytest.raises(requests.exceptions.HTTPError):
+        app_static.api_key = None
         app_static.records("object_3", refresh=True)
 
 
-def test_get_with_filters(app_live):
+def test_get_object_records_with_filters(app_live):
     records = app_live.records("object_3", filters=FILTERS)
     assert len([record for record in records]) == 1
+
+
+def test_get_view_records_with_filters(app_live):
+    records = app_live.records("view_11", filters=FILTERS)
+    assert len([record for record in records]) == 1
+
+
+def test_get_records_by_object_name(app_static):
+    assert app_static.records("orders")
+
+
+def test_get_records_by_view_name(app_static):
+    assert app_static.records("all fields")
 
 
 def test_get_by_dupe_name_fail(app_static):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -111,6 +111,22 @@ def test_get_records_by_view_name(app_static):
     assert app_static.records("all fields")
 
 
+def test_no_key_or_name_param(app_static):
+    # the API allows you to use App.reords() (without any key or view name) if only
+    # one container has been retrieved. in this case, it's the sideloaded records in
+    # object_3.
+    assert app_static.records()
+
+def test_no_key_or_name_param_fail(app_static):
+    # the API allows you to use App.reords() (without any key or view name) if only
+    # one container has been retrieved. in this case, we side-load additional data
+    # such that the app is holding data for two containers, and so the user must
+    # specifiy the container name or key
+    data = app_static.data["object_3"]
+    app_static.data["fake_data_holder"] = data
+    with pytest.raises(TypeError):
+        assert app_static.records()
+
 def test_get_by_dupe_name_fail(app_static):
     # the "all_fields_test" container name exists in our app as both an object
     # and as a view. so trying to query by that name results in a KeyError.


### PR DESCRIPTION
- tests for views and name-based record requests
- allow omission of container string arg in `App.records()`
- restore lost `id` field handling