### PR TITLE
Add Random Sleep to Tests

### DIFF
--- a/knackpy/app.py
+++ b/knackpy/app.py
@@ -307,8 +307,6 @@ class App:
         for record in records:
             record_formatted = {}
             for field in record.values():
-                if not field:
-                    breakpoint()
                 try:
                     subfields = FIELD_SETTINGS[field.field_def.type]["subfields"]
                 except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def build_config(env, readme="README.md"):
         "packages": ["knackpy"],
         "tests_require": ["pytest", "coverage"],
         "url": "http://github.com/cityofaustin/knackpy",
-        "version": "1.0.8",
+        "version": "1.0.9",
     }
 
 


### PR DESCRIPTION
Automated tests occasionally fail with HTTP errors because we're running the package tests on 3 versions of Python concurrently. This is an attempt to add a bit of random sleep between API requests.