### PR TITLE
v1.0.16

### DIFF
--- a/knackpy/api.py
+++ b/knackpy/api.py
@@ -5,7 +5,6 @@ import math
 import random
 import time
 import typing
-import warnings
 
 import requests
 
@@ -166,7 +165,7 @@ def _get_paginated_records(
                     raise e
 
                 if attempts < max_attempts:
-                    warnings.warn(
+                    logging.debug(
                         f"Error on attempt #{attempts}: {e.__repr__()}"
                     )
                     attempts += 1

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def build_config(env, readme="README.md"):
         "packages": ["knackpy"],
         "tests_require": ["pytest", "coverage"],
         "url": "http://github.com/cityofaustin/knackpy",
-        "version": "1.0.15",
+        "version": "1.0.16",
     }
 
 


### PR DESCRIPTION
- Replace `warnings.warn` with `logging.debug`