### PR TITLE
modify default formatter to handle lists

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -22,9 +22,9 @@ $ pip install -e knackpy
 
 We test with [`pytest`](docs.pytest.org/en/stable), [`coverage`](coverage.readthedocs.io), and [`pytest-env`](https://github.com/MobileDynasty/pytest-env).
 
-### Knacky Development Knack Application
+### Knackpy Development Knack Application
 
-Tests for `app.py` and `api.py` are dependendent on a City of Austin-owned Knack application which we rely on for over-the-wire API tests. If you work for the City of Austin Transportation Department, the credentials for this app are in our password store, and the app is called "Knackpy Development".
+Tests for `app.py` and `api.py` are dependent on a City of Austin-owned Knack application which we rely on for over-the-wire API tests. If you work for the City of Austin Transportation Department, the credentials for this app are in our password store, and the app is called "Knackpy Development".
 
 Any modifications you make to the Knackpy Development app may impact tests. You should carefully review our `tests/` before you modify _anything_ in the development app.
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -58,9 +58,9 @@ Knackpy is designed around the `App` class. It provides helpers for querying
 and manipulating Knack application data. You should use the `App` class
 because:
 
-- It allows you to query obejcts and views by key or name
+- It allows you to query objects and views by key or name
 - It takes care of [localization issues](#timestamps-and-localization)
-- It let's you download and upload files from your app.
+- It lets you download and upload files from your app.
 - It does other things, too.
 
 To create an `App` instance, the bare minimum you need to provide is your [application ID](https://www.knack.com/developer-documentation/#find-your-api-key-amp-application-id).
@@ -102,7 +102,7 @@ For faster performance, set `generate=true` when getting records from your app. 
 Namespace conflicts are highly likely when fetching by name, because Knack uses object names as the default name for views. If you attempt to query your application by a name that exists as both an object and a view, Knackpy will raise a `ValueError`.
 {{< /hint >}}
 
-You can resuse the same `App` instance to fetch records from other objects and views.
+You can reuse the same `App` instance to fetch records from other objects and views.
 
 ```python
 >>> app.get("my_exciting_object")

--- a/knackpy/formatters.py
+++ b/knackpy/formatters.py
@@ -7,7 +7,8 @@ def default(value: object):
     (aka, humanized) value.
 
     The `default()` formatter handles any field type for which another formatter
-    function has not been defined. It simply returns the input value without additional
+    function has not been defined. If the input value is a list, it returns a comma separated
+    string of list values. Otherwise, it simply returns the input value without additional
     formatting.
 
     You'll notice that each formatter function's name matches its field type. If you
@@ -15,6 +16,8 @@ def default(value: object):
 
     See also: knackpy.Fields
     """
+    if isinstance(value, list):
+      return ", ".join(str(v) for v in value)
     return value
 
 

--- a/knackpy/record.py
+++ b/knackpy/record.py
@@ -125,7 +125,7 @@ class Record(MutableMapping):
             # store the raw data if available
             value = self.raw[key_raw] if key_raw in self.raw else self.raw[key]
 
-            # there are a fiew fields where it's easier to just use knack's formatted
+            # there are a few fields where it's easier to just use knack's formatted
             # value. E.g. timer and name. in those cases, we want to store knack's
             # formatted value so that we can reference it when we assign a value to
             # Field.formatted.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def build_config(env, readme="README.md"):
         "packages": ["knackpy"],
         "tests_require": ["pytest", "coverage"],
         "url": "http://github.com/cityofaustin/knackpy",
-        "version": "1.0.17",
+        "version": "1.0.18",
     }
 
 


### PR DESCRIPTION
Ran into an issue when formatting records where a `short_text` field was being returned as a list, its raw value. 

The field came back as a list because it belonged to an object that is the “many” in a one-many relationship to locations. 

Modifies the default formatter to return a list as a string.