### PR TITLE
Add failsafe to prevent infinite record fetch loop

### DIFF
--- a/knackpy/api.py
+++ b/knackpy/api.py
@@ -10,6 +10,7 @@ import requests
 
 from .models import MAX_ROWS_PER_PAGE
 
+logger = logging.getLogger(__name__)
 
 def _random_pause():
     """sleep for at least .333 seconds"""
@@ -113,7 +114,7 @@ def _request(
     attempts = 1
 
     while True:
-        logging.debug(
+        logger.debug(
             f"{method} to {url} with {params or 'no params'} (Attempt {attempts}/{max_attempts})"  # noqa:E501
         )
 
@@ -129,7 +130,7 @@ def _request(
                 raise e
 
             if attempts < max_attempts:
-                logging.debug(f"Error on attempt #{attempts}: {e.__repr__()}")
+                logger.debug(f"Error on attempt #{attempts}: {e.__repr__()}")
                 attempts += 1
                 _random_pause()
                 continue
@@ -165,7 +166,7 @@ def _get_paginated_records(
 
     while _continue(total_records, len(records), record_limit):
         params = {"page": page, "rows_per_page": rows_per_page, "filters": filters}
-        logging.debug(f"Getting {rows_per_page} records from page {page} from {url}")
+        logger.debug(f"Getting {rows_per_page} records from page {page} from {url}")
         res = _request(
             method="GET",
             url=url,

--- a/knackpy/app.py
+++ b/knackpy/app.py
@@ -12,6 +12,7 @@ from . import api, fields, utils
 from . import record as knackpy_record
 from .models import TIMEZONES, FIELD_SETTINGS
 
+logger = logging.getLogger(__name__)
 
 class App:
     """Knackpy is designed around the `App` class. It provides helpers for querying
@@ -78,7 +79,7 @@ class App:
         self.containers = utils.generate_containers(self.metadata)
         self.data = {}
         self.records = {}
-        logging.debug(self)
+        logger.debug(self)
 
     def _get_metadata(self):
         return api.get_metadata(app_id=self.app_id, timeout=self.timeout)
@@ -450,7 +451,7 @@ class App:
         for file_info in downloads:
             filename = file_info["filename"]
             filesize = utils.humanize_bytes(file_info["size"])
-            logging.debug(f"\nDownloading {file_info['url']} - size: {filesize}")
+            logger.debug(f"\nDownloading {file_info['url']} - size: {filesize}")
 
             res = requests.get(file_info["url"], allow_redirects=True)
 
@@ -501,7 +502,7 @@ class App:
 
         download_count = self._download_files(downloads)
 
-        logging.debug(f"{download_count} files downloaded.")
+        logger.debug(f"{download_count} files downloaded.")
 
         return download_count
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def build_config(env, readme="README.md"):
         "packages": ["knackpy"],
         "tests_require": ["pytest", "coverage"],
         "url": "http://github.com/cityofaustin/knackpy",
-        "version": "1.0.19",
+        "version": "1.0.20",
     }
 
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def build_config(env, readme="README.md"):
         "packages": ["knackpy"],
         "tests_require": ["pytest", "coverage"],
         "url": "http://github.com/cityofaustin/knackpy",
-        "version": "1.0.18",
+        "version": "1.0.19",
     }
 
 


### PR DESCRIPTION
Fixes #91.

Also adopts [standard module logging](https://docs.python.org/3/howto/logging.html#advanced-logging-tutorial) behavior. 